### PR TITLE
Disable static compilation for osx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,13 @@ GOCMD=go
 GOBUILD=$(GOCMD) build
 GOMOD=$(GOCMD) mod
 GOTEST=$(GOCMD) test
-GOGET=$(GOCMD) get
+GOFLAGS := -v 
+LDFLAGS := -s -w
     
 all: build
 build:
-		$(GOBUILD) -v -ldflags="-extldflags=-static" -o "mapcidr" cmd/mapcidr/main.go
+	$(GOBUILD) $(GOFLAGS) -ldflags '$(LDFLAGS)' -o "mapcidr" cmd/mapcidr/main.go
 test: 
-		$(GOTEST) -v ./...
+	$(GOTEST) -v ./...
 tidy:
-		$(GOMOD) tidy
+	$(GOMOD) tidy

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ GOMOD=$(GOCMD) mod
 GOTEST=$(GOCMD) test
 GOFLAGS := -v 
 LDFLAGS := -s -w
+
+ifneq ($(shell go env GOOS),darwin)
+LDFLAGS := -extldflags "-static"
+endif
     
 all: build
 build:


### PR DESCRIPTION
## Description
This PR disables static compilation for OSX and enables few compiler flags to reduce binary size and strip debugging symbols.