### PR TITLE
Update main.go

### DIFF
--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -62,7 +62,7 @@ const banner = `
 `
 
 // Version is the current version of mapcidr
-const version = `v1.1.9`
+const version = `v1.1.12`
 
 // showBanner is used to show the banner to the user
 func showBanner() {


### PR DESCRIPTION
Ensure banner in main.go reflects current version number upon each release to avoid confusing users after updates.