### PR TITLE
fix binary version mismatch

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -3,7 +3,7 @@ name: Bump Version
 on:
   workflow_dispatch:
   schedule:
-    - cron: "55 23 * * 0"
+    - cron: "30 23 * * 6"
 
 jobs:
   version_bump:
@@ -16,11 +16,11 @@ jobs:
 
       - name: Get Commit Count
         id: get_commit
-        run: git rev-list  `git rev-list --tags --no-walk --max-count=1`..HEAD --count | xargs -I {} echo COMMIT_COUNT={} >> $GITHUB_OUTPUT
+        run: git rev-list "$(git rev-list --tags --no-walk --max-count=1)"..HEAD --count | xargs -I {} echo "COMMIT_COUNT={}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Go
         if: ${{ steps.get_commit.outputs.COMMIT_COUNT > 0  }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.24.0
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ before:
 builds:
 - binary: '{{ .ProjectName }}'
   main: cmd/mapcidr/main.go
+  ldflags:
+    - -s -w -X main.version={{.Tag}}
   goos: [windows,linux,darwin]
   goarch: [amd64,386,arm,arm64]
   ignore:

--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -77,7 +77,7 @@ const banner = `
 `
 
 // Version is the current version of mapcidr
-const version = `v1.1.116`
+var version = `v1.1.116`
 
 // showBanner is used to show the banner to the user
 func showBanner() {


### PR DESCRIPTION
closes #695

- inject version from git tag via goreleaser ldflags
- change `const version` to `var version` so ldflags can override it
- fix version-bump cron to run before auto-release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code structure update with no impact on user-facing functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->