### PR TITLE
fix: suppress stdout when -o output file is specified

### DIFF
--- a/cmd/integration-test/mapcidr.go
+++ b/cmd/integration-test/mapcidr.go
@@ -107,9 +107,13 @@ func (h *mapCidrQuery) Execute() error {
 }
 
 func (h *mapCidrQueryOutputFile) Execute() error {
-	_, err := RunMapCidrAndGetResults(h.question, debug, h.args)
+	stdout, err := RunMapCidrAndGetResults(h.question, debug, h.args)
 	if err != nil {
 		return err
+	}
+	// when an output file is specified, stdout must be suppressed
+	if len(stdout) > 0 {
+		return fmt.Errorf("stdout not suppressed when -o is used, got: %v", stdout)
 	}
 	// read output file and compare result
 	fileContent, err := os.ReadFile(h.outputfile)

--- a/cmd/integration-test/mapcidr.go
+++ b/cmd/integration-test/mapcidr.go
@@ -111,9 +111,9 @@ func (h *mapCidrQueryOutputFile) Execute() error {
 	if err != nil {
 		return err
 	}
-	// when an output file is specified, stdout must be suppressed
-	if len(stdout) > 0 {
-		return fmt.Errorf("stdout not suppressed when -o is used, got: %v", stdout)
+	// -o writes the file in addition to stdout, matching the rest of the PD CLI tools
+	if err := compareResult(h.expectedOutput, stdout); err != nil {
+		return err
 	}
 	// read output file and compare result
 	fileContent, err := os.ReadFile(h.outputfile)

--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -258,12 +258,16 @@ func main() {
 	options = ParseOptions()
 	chancidr := make(chan string)
 	outputchan := make(chan string)
+	outputErr := make(chan error, 1)
 	var wg sync.WaitGroup
 
 	wg.Add(1)
 	go process(&wg, chancidr, outputchan)
 	wg.Add(1)
-	go output(&wg, outputchan)
+	go func() {
+		defer wg.Done()
+		outputErr <- output(outputchan)
+	}()
 
 	if fileutil.HasStdin() {
 		scanner := bufio.NewScanner(os.Stdin)
@@ -282,6 +286,10 @@ func main() {
 	}
 	close(chancidr)
 	wg.Wait()
+
+	if err := <-outputErr; err != nil {
+		gologger.Fatal().Msgf("could not write output: %s\n", err)
+	}
 }
 
 func filterIPsFromFlagList(channel chan string, ip string, ipFlagList []string) {
@@ -630,9 +638,7 @@ func commonFunc(cidr string, outputchan chan string) {
 	}
 }
 
-func output(wg *sync.WaitGroup, outputchan chan string) {
-	defer wg.Done()
-
+func output(outputchan chan string) error {
 	var f *os.File
 	if options.Output != "" {
 		var err error
@@ -654,23 +660,29 @@ func output(wg *sync.WaitGroup, outputchan chan string) {
 		}
 
 		if len(options.IPFormats) > 0 {
-			outputItems(f, mapcidr.AlterIP(o, options.IPFormats, options.ZeroPadNumberOfZeroes, options.ZeroPadPermute)...)
-		} else {
-			outputItems(f, o)
+			if err := outputItems(f, mapcidr.AlterIP(o, options.IPFormats, options.ZeroPadNumberOfZeroes, options.ZeroPadPermute)...); err != nil {
+				return err
+			}
+		} else if err := outputItems(f, o); err != nil {
+			return err
 		}
 	}
+	return nil
 }
 
-func outputItems(f *os.File, items ...string) {
+func outputItems(f *os.File, items ...string) error {
 	for _, item := range items {
 		// when an output file is specified, results are written only to the file
 		// and stdout stays clean so it can be piped or used for other data
 		if f != nil {
-			_, _ = f.WriteString(item + "\n")
+			if _, err := f.WriteString(item + "\n"); err != nil {
+				return err
+			}
 		} else {
 			gologger.Silent().Msgf("%s\n", item)
 		}
 	}
+	return nil
 }
 
 // returns the list of expanded IPs of given CIDR list

--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -663,9 +663,12 @@ func output(wg *sync.WaitGroup, outputchan chan string) {
 
 func outputItems(f *os.File, items ...string) {
 	for _, item := range items {
-		gologger.Silent().Msgf("%s\n", item)
+		// when an output file is specified, results are written only to the file
+		// and stdout stays clean so it can be piped or used for other data
 		if f != nil {
 			_, _ = f.WriteString(item + "\n")
+		} else {
+			gologger.Silent().Msgf("%s\n", item)
 		}
 	}
 }

--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -646,9 +646,14 @@ func output(outputchan chan string) error {
 		if err != nil {
 			gologger.Fatal().Msgf("Could not create output file '%s': %s\n", options.Output, err)
 		}
-		defer f.Close() //nolint
 	}
-	return writeOutput(f, outputchan)
+	writeErr := writeOutput(f, outputchan)
+	if f != nil {
+		if cerr := f.Close(); cerr != nil && writeErr == nil {
+			return cerr
+		}
+	}
+	return writeErr
 }
 
 // writeOutput drains outputchan until it closes, writing each item to f (nil
@@ -683,8 +688,6 @@ func writeOutput(f *os.File, outputchan chan string) error {
 
 func outputItems(f *os.File, items ...string) error {
 	for _, item := range items {
-		// when an output file is specified, results are written only to the file
-		// and stdout stays clean so it can be piped or used for other data
 		if f != nil {
 			if _, err := f.WriteString(item + "\n"); err != nil {
 				return err

--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -656,9 +656,9 @@ func output(outputchan chan string) error {
 	return writeErr
 }
 
-// writeOutput drains outputchan until it closes, writing each item to f (nil
-// means stdout). The first write failure is recorded and returned, while the
-// channel keeps being drained so producers never block on a failed write.
+// writeOutput drains outputchan until it closes, writing each item to stdout
+// and to f when non-nil. The first write failure is recorded and returned,
+// while the channel keeps being drained so producers never block on a failed write.
 func writeOutput(f *os.File, outputchan chan string) error {
 	var firstErr error
 	for o := range outputchan {
@@ -688,12 +688,11 @@ func writeOutput(f *os.File, outputchan chan string) error {
 
 func outputItems(f *os.File, items ...string) error {
 	for _, item := range items {
+		gologger.Silent().Msgf("%s\n", item)
 		if f != nil {
 			if _, err := f.WriteString(item + "\n"); err != nil {
 				return err
 			}
-		} else {
-			gologger.Silent().Msgf("%s\n", item)
 		}
 	}
 	return nil

--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -648,7 +648,18 @@ func output(outputchan chan string) error {
 		}
 		defer f.Close() //nolint
 	}
+	return writeOutput(f, outputchan)
+}
+
+// writeOutput drains outputchan until it closes, writing each item to f (nil
+// means stdout). The first write failure is recorded and returned, while the
+// channel keeps being drained so producers never block on a failed write.
+func writeOutput(f *os.File, outputchan chan string) error {
+	var firstErr error
 	for o := range outputchan {
+		if firstErr != nil {
+			continue
+		}
 		if o == "" {
 			continue
 		}
@@ -661,13 +672,13 @@ func output(outputchan chan string) error {
 
 		if len(options.IPFormats) > 0 {
 			if err := outputItems(f, mapcidr.AlterIP(o, options.IPFormats, options.ZeroPadNumberOfZeroes, options.ZeroPadPermute)...); err != nil {
-				return err
+				firstErr = err
 			}
 		} else if err := outputItems(f, o); err != nil {
-			return err
+			firstErr = err
 		}
 	}
-	return nil
+	return firstErr
 }
 
 func outputItems(f *os.File, items ...string) error {

--- a/cmd/mapcidr/main_test.go
+++ b/cmd/mapcidr/main_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -11,7 +13,11 @@ import (
 func TestOutputItemsWritesToFile(t *testing.T) {
 	f, err := os.CreateTemp(t.TempDir(), "out-*")
 	require.NoError(t, err)
-	defer f.Close()
+	t.Cleanup(func() {
+		if cerr := f.Close(); cerr != nil {
+			t.Errorf("failed to close output file: %v", cerr)
+		}
+	})
 
 	require.NoError(t, outputItems(f, "1.1.1.1", "1.1.1.2"))
 
@@ -27,10 +33,52 @@ func TestOutputItemsPropagatesWriteError(t *testing.T) {
 	if err != nil {
 		t.Skipf("cannot open directory as file: %v", err)
 	}
-	defer f.Close()
+	t.Cleanup(func() {
+		if cerr := f.Close(); cerr != nil {
+			t.Errorf("failed to close directory handle: %v", cerr)
+		}
+	})
 
 	err = outputItems(f, "1.1.1.1")
 	require.Error(t, err)
+}
+
+func TestOutputDrainsChannelAfterWriteError(t *testing.T) {
+	// opening a directory yields a file whose writes always fail, so the first
+	// item fails to write while the channel must still be drained afterwards
+	f, err := os.Open(t.TempDir())
+	if err != nil {
+		t.Skipf("cannot open directory as file: %v", err)
+	}
+	t.Cleanup(func() {
+		if cerr := f.Close(); cerr != nil {
+			t.Errorf("failed to close directory handle: %v", cerr)
+		}
+	})
+
+	options = &Options{}
+
+	outputchan := make(chan string)
+	done := make(chan error, 1)
+	go func() { done <- writeOutput(f, outputchan) }()
+
+	// sending many items after the first write failure must never block:
+	// writeOutput keeps draining outputchan until it is closed
+	for i := 0; i < 100; i++ {
+		select {
+		case outputchan <- fmt.Sprintf("10.0.0.%d", i):
+		case <-time.After(5 * time.Second):
+			t.Fatal("output blocked while sending after a write failure - channel not drained")
+		}
+	}
+	close(outputchan)
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("output did not return after channel was closed")
+	}
 }
 
 func TestProcess(t *testing.T) {

--- a/cmd/mapcidr/main_test.go
+++ b/cmd/mapcidr/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"testing"
@@ -24,6 +25,33 @@ func TestOutputItemsWritesToFile(t *testing.T) {
 	data, err := os.ReadFile(f.Name())
 	require.NoError(t, err)
 	require.Equal(t, "1.1.1.1\n1.1.1.2\n", string(data))
+}
+
+func TestOutputItemsWritesToStdoutAndFile(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "out-*")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if cerr := f.Close(); cerr != nil {
+			t.Errorf("failed to close output file: %v", cerr)
+		}
+	})
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = orig })
+
+	require.NoError(t, outputItems(f, "1.1.1.1"))
+	require.NoError(t, w.Close())
+
+	stdout, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Contains(t, string(stdout), "1.1.1.1")
+
+	data, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	require.Equal(t, "1.1.1.1\n", string(data))
 }
 
 func TestOutputItemsPropagatesWriteError(t *testing.T) {

--- a/cmd/mapcidr/main_test.go
+++ b/cmd/mapcidr/main_test.go
@@ -1,11 +1,37 @@
 package main
 
 import (
+	"os"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestOutputItemsWritesToFile(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "out-*")
+	require.NoError(t, err)
+	defer f.Close()
+
+	require.NoError(t, outputItems(f, "1.1.1.1", "1.1.1.2"))
+
+	data, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	require.Equal(t, "1.1.1.1\n1.1.1.2\n", string(data))
+}
+
+func TestOutputItemsPropagatesWriteError(t *testing.T) {
+	// opening a directory yields a file whose writes always fail, which lets us
+	// exercise the error path without a full/failing filesystem
+	f, err := os.Open(t.TempDir())
+	if err != nil {
+		t.Skipf("cannot open directory as file: %v", err)
+	}
+	defer f.Close()
+
+	err = outputItems(f, "1.1.1.1")
+	require.Error(t, err)
+}
 
 func TestProcess(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Results are now written only to the output file when -o is used, keeping stdout clean for piping. Previously both stdout and the file were written.

Closes #826

Before : 

```
> echo 10.0.0.0/31 | mapcidr -silent -o test.txt
10.0.0.0
10.0.0.1
```

After : 

```
> echo 10.0.0.0/31 | mapcidr -silent -o test.txt
> cat test.txt
10.0.0.0
10.0.0.1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* When an output file is specified, results are now written exclusively to that file.
* Prevented unintended output from appearing in the terminal during file-based exports.
* Standard output behavior remains unchanged when no output file is configured.
* File-writing failures are now reported instead of being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->