### PR TITLE
fix: remove temporary /tmp/mapcidr* directories created during execution

### DIFF
--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -253,6 +253,14 @@ func (options *Options) configureOutput() {
 }
 
 var options *Options
+var rangerCloser func()
+
+func closeAndFatal(format string, args ...interface{}) {
+	if rangerCloser != nil {
+		rangerCloser()
+	}
+	gologger.Fatal().Msgf(format, args...)
+}
 
 func main() {
 	options = ParseOptions()
@@ -398,7 +406,16 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 	if err != nil {
 		gologger.Fatal().Msgf("%s\n", err)
 	}
-	defer func() { _ = ranger.Close() }()
+	var closeOnce sync.Once
+	closeRanger := func() {
+		closeOnce.Do(func() { _ = ranger.Close() })
+	}
+	defer closeRanger()
+	rangerCloser = closeRanger
+	fatalf := func(format string, args ...interface{}) {
+		closeRanger()
+		gologger.Fatal().Msgf(format, args...)
+	}
 	for cidr := range chancidr {
 		// if it's an ip turn it into a cidr
 		if ip := net.ParseIP(cidr); ip != nil {
@@ -416,15 +433,15 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 		if len(options.FilterIP) > 0 && strings.Contains(cidr, "/") {
 			inputNetworks, err := cidrsToNetworks([]string{cidr})
 			if err != nil {
-				gologger.Fatal().Msgf("%s\n", err)
+				fatalf("%s\n", err)
 			}
 			filterNetworks, err := cidrsToNetworks(options.FilterIP)
 			if err != nil {
-				gologger.Fatal().Msgf("%s\n", err)
+				fatalf("%s\n", err)
 			}
 			newNetworks, err := mapcidr.RemoveCIDRs(inputNetworks, filterNetworks)
 			if err != nil {
-				gologger.Fatal().Msgf("%s\n", err)
+				fatalf("%s\n", err)
 			}
 			cidrsToProcess = make([]string, 0, len(newNetworks))
 			for _, newNet := range newNetworks {
@@ -439,7 +456,7 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 				if strings.Count(cidr, ".") == 3 {
 					ips, err := mapcidr.ExpandIPPattern(cidr)
 					if err != nil {
-						gologger.Fatal().Msgf("%s\n", err)
+						fatalf("%s\n", err)
 					}
 
 					for _, ip := range ips {
@@ -460,7 +477,7 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 					ipRange = append(ipRange, net.ParseIP(ipstr))
 				}
 				if len(ipRange) > 2 {
-					gologger.Fatal().Msgf("IP range can not have more than 2 values.")
+					fatalf("IP range can not have more than 2 values.")
 				}
 				ipRangeList = append(ipRangeList, ipRange)
 				continue
@@ -474,7 +491,7 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 
 			// test if we have a cidr
 			if _, pCidr, err = net.ParseCIDR(cidr); err != nil {
-				gologger.Fatal().Msgf("%s\n", err)
+				fatalf("%s\n", err)
 			}
 
 			// filters ip4|ip6, by default do not filter
@@ -499,7 +516,7 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 	for _, ipRange := range ipRangeList {
 		cidrs, err := mapcidr.GetCIDRFromIPRange(ipRange[0], ipRange[1])
 		if err != nil {
-			gologger.Fatal().Msgf("%s\n", err)
+			fatalf("%s\n", err)
 		}
 		if options.Aggregate || options.Shuffle || hasSort || options.AggregateApprox || options.Count {
 			allCidrs = append(allCidrs, cidrs...)
@@ -513,7 +530,7 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 	for _, asnNumber := range asnNumberList {
 		cidrs, err := asn.GetCIDRsForASNNum(asnNumber)
 		if err != nil {
-			gologger.Fatal().Msgf("%s\n", err)
+			fatalf("%s\n", err)
 		}
 		if options.Aggregate || options.Shuffle || hasSort || options.AggregateApprox || options.Count {
 			allCidrs = append(allCidrs, cidrs...)
@@ -531,7 +548,7 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 			for _, p := range strings.Split(options.ShufflePorts, ",") {
 				port, err := strconv.Atoi(p)
 				if err != nil {
-					gologger.Fatal().Msgf("%s\n", err)
+					fatalf("%s\n", err)
 				}
 				ports = append(ports, port)
 			}
@@ -578,7 +595,7 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 	if options.AggregateApprox {
 		ipnet, err := mapcidr.AggregateApproxIPv4To24(allCidrs)
 		if err != nil {
-			gologger.Fatal().Msgf("%s\n", err)
+			fatalf("%s\n", err)
 		}
 		for _, cidr := range ipnet {
 			outputchan <- cidr.String()
@@ -602,11 +619,11 @@ func commonFunc(cidr string, outputchan chan string) {
 	if options.Range {
 		_, network, err := net.ParseCIDR(cidr)
 		if err != nil {
-			gologger.Fatal().Msgf("%s\n", err)
+			closeAndFatal("%s\n", err)
 		}
 		firstIP, lastIP, err := mapcidr.AddressRange(network)
 		if err != nil {
-			gologger.Fatal().Msgf("%s\n", err)
+			closeAndFatal("%s\n", err)
 		}
 		outputchan <- fmt.Sprintf("%s-%s", firstIP, lastIP)
 		return
@@ -614,7 +631,7 @@ func commonFunc(cidr string, outputchan chan string) {
 	if options.Slices > 0 {
 		subnets, err := mapcidr.SplitN(cidr, options.Slices)
 		if err != nil {
-			gologger.Fatal().Msgf("%s\n", err)
+			closeAndFatal("%s\n", err)
 		}
 		for _, subnet := range subnets {
 			outputchan <- subnet.String()
@@ -622,7 +639,7 @@ func commonFunc(cidr string, outputchan chan string) {
 	} else if options.HostCount > 0 {
 		subnets, err := mapcidr.SplitByNumber(cidr, options.HostCount)
 		if err != nil {
-			gologger.Fatal().Msgf("%s\n", err)
+			closeAndFatal("%s\n", err)
 		}
 		for _, subnet := range subnets {
 			outputchan <- subnet.String()
@@ -634,7 +651,7 @@ func commonFunc(cidr string, outputchan chan string) {
 
 		ips, err := mapcidr.IPAddressesAsStream(cidr)
 		if err != nil {
-			gologger.Fatal().Msgf("%s\n", err)
+			closeAndFatal("%s\n", err)
 		}
 		for ip := range ips {
 			filterIPsFromFlagList(outputchan, ip, ipFlagList)
@@ -708,7 +725,7 @@ func getIPList(cidrs []*net.IPNet) []net.IP {
 	for _, cidr := range cidrs {
 		ips, err := mapcidr.IPAddressesAsStream(cidr.String())
 		if err != nil {
-			gologger.Fatal().Msgf("%s\n", err)
+			closeAndFatal("%s\n", err)
 		}
 		for ip := range ips {
 			ipList = append(ipList, net.ParseIP(ip))

--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -408,7 +408,11 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 	}
 	var closeOnce sync.Once
 	closeRanger := func() {
-		closeOnce.Do(func() { _ = ranger.Close() })
+		closeOnce.Do(func() {
+			if err := ranger.Close(); err != nil {
+				gologger.Error().Msgf("%s\n", err)
+			}
+		})
 	}
 	defer closeRanger()
 	rangerCloser = closeRanger

--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/signal"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/projectdiscovery/goflags"
@@ -252,10 +255,73 @@ func (options *Options) configureOutput() {
 	}
 }
 
-var options *Options
+var (
+	options *Options
+	// createdTempDirs stores directories created by this process
+	createdTempDirs []string
+	// tempOwnerID identifies ownership of created temp dirs
+	tempOwnerID string
+	// ensure cleanup runs only once
+	cleanupOnce sync.Once
+)
+
+// registerTempOwner sets an owner identifier and installs signal handlers so
+// cleanupTempDirs runs on SIGINT/SIGTERM. The owner identifier is the PID to
+// avoid adding extra dependencies; it is written into each temp directory's
+// .mapcidr-owner file by callers that create temp dirs.
+func registerTempOwner() {
+	tempOwnerID = strconv.Itoa(os.Getpid())
+	// handle signals to trigger cleanup
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		cleanupOnce.Do(cleanupTempDirs)
+		os.Exit(1)
+	}()
+}
+
+// cleanupTempDirs removes only directories under the system temp directory
+// that contain a .mapcidr-owner file matching this process's owner id. This
+// prevents accidental removal of directories created by other processes.
+func cleanupTempDirs() {
+	tmp := os.TempDir()
+	pattern := filepath.Join(tmp, "mapcidr*")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return
+	}
+	for _, d := range matches {
+		// guard path
+		abs, err := filepath.Abs(d)
+		if err != nil {
+			continue
+		}
+		tmpAbs, err := filepath.Abs(tmp)
+		if err != nil {
+			continue
+		}
+		if !strings.HasPrefix(abs, tmpAbs) {
+			continue
+		}
+
+		ownerFile := filepath.Join(d, ".mapcidr-owner")
+		data, err := os.ReadFile(ownerFile)
+		if err != nil {
+			// no owner file, skip
+			continue
+		}
+		if string(data) == tempOwnerID {
+			_ = os.RemoveAll(abs)
+		}
+	}
+}
 
 func main() {
 	options = ParseOptions()
+	// register owner and ensure cleanup runs once on exit or signal
+	registerTempOwner()
+	defer cleanupOnce.Do(cleanupTempDirs)
 	chancidr := make(chan string)
 	outputchan := make(chan string)
 	outputErr := make(chan error, 1)

--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -7,13 +7,10 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/signal"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/projectdiscovery/goflags"
@@ -255,95 +252,10 @@ func (options *Options) configureOutput() {
 	}
 }
 
-var (
-	options *Options
-	// createdTempDirs stores directories created by this process
-	createdTempDirs []string
-	// tempOwnerID identifies ownership of created temp dirs
-	tempOwnerID string
-	// ensure cleanup runs only once
-	cleanupOnce sync.Once
-)
-
-// registerTempOwner sets an owner identifier and installs signal handlers so
-// cleanupTempDirs runs on SIGINT/SIGTERM. The owner identifier is the PID to
-// avoid adding extra dependencies; it is written into each temp directory's
-// .mapcidr-owner file by callers that create temp dirs.
-func registerTempOwner() {
-	tempOwnerID = strconv.Itoa(os.Getpid())
-	// handle signals to trigger cleanup
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigs
-		cleanupOnce.Do(cleanupTempDirs)
-		os.Exit(1)
-	}()
-}
-
-// cleanupTempDirs removes only directories under the system temp directory
-// that contain a .mapcidr-owner file matching this process's owner id. This
-// prevents accidental removal of directories created by other processes.
-func cleanupTempDirs() {
-	tmp := os.TempDir()
-	pattern := filepath.Join(tmp, "mapcidr*")
-	matches, err := filepath.Glob(pattern)
-	if err != nil {
-		return
-	}
-	for _, d := range matches {
-		// guard path
-		abs, err := filepath.Abs(d)
-		if err != nil {
-			continue
-		}
-		tmpAbs, err := filepath.Abs(tmp)
-		if err != nil {
-			continue
-		}
-		if !strings.HasPrefix(abs, tmpAbs) {
-			continue
-		}
-
-		ownerFile := filepath.Join(d, ".mapcidr-owner")
-		data, err := os.ReadFile(ownerFile)
-		if err != nil {
-			// no owner file, skip
-			continue
-		}
-		if string(data) == tempOwnerID {
-			_ = os.RemoveAll(abs)
-		}
-	}
-}
-
-// CreateOwnedTempDir creates a temporary directory under the system temp dir,
-// writes a .mapcidr-owner file containing the tempOwnerID, records it for
-// potential bookkeeping, and returns the directory path.
-func CreateOwnedTempDir(prefix string) (string, error) {
-	if tempOwnerID == "" {
-		// ensure owner is registered
-		registerTempOwner()
-	}
-	dir, err := os.MkdirTemp("", prefix+"mapcidr-")
-	if err != nil {
-		return "", err
-	}
-	ownerFile := filepath.Join(dir, ".mapcidr-owner")
-	if err := os.WriteFile(ownerFile, []byte(tempOwnerID), 0o600); err != nil {
-		// best-effort cleanup on write failure
-		_ = os.RemoveAll(dir)
-		return "", err
-	}
-	createdTempDirs = append(createdTempDirs, dir)
-	return dir, nil
-}
+var options *Options
 
 func main() {
 	options = ParseOptions()
-	// register owner and ensure cleanup runs once on exit or signal
-	registerTempOwner()
-	defer cleanupOnce.Do(cleanupTempDirs)
 	chancidr := make(chan string)
 	outputchan := make(chan string)
 	outputErr := make(chan error, 1)
@@ -482,7 +394,11 @@ func process(wg *sync.WaitGroup, chancidr, outputchan chan string) {
 		asnNumberList []string
 	)
 
-	ranger, _ = ipranger.New()
+	ranger, err = ipranger.New()
+	if err != nil {
+		gologger.Fatal().Msgf("%s\n", err)
+	}
+	defer func() { _ = ranger.Close() }()
 	for cidr := range chancidr {
 		// if it's an ip turn it into a cidr
 		if ip := net.ParseIP(cidr); ip != nil {

--- a/cmd/mapcidr/main.go
+++ b/cmd/mapcidr/main.go
@@ -317,6 +317,28 @@ func cleanupTempDirs() {
 	}
 }
 
+// CreateOwnedTempDir creates a temporary directory under the system temp dir,
+// writes a .mapcidr-owner file containing the tempOwnerID, records it for
+// potential bookkeeping, and returns the directory path.
+func CreateOwnedTempDir(prefix string) (string, error) {
+	if tempOwnerID == "" {
+		// ensure owner is registered
+		registerTempOwner()
+	}
+	dir, err := os.MkdirTemp("", prefix+"mapcidr-")
+	if err != nil {
+		return "", err
+	}
+	ownerFile := filepath.Join(dir, ".mapcidr-owner")
+	if err := os.WriteFile(ownerFile, []byte(tempOwnerID), 0o600); err != nil {
+		// best-effort cleanup on write failure
+		_ = os.RemoveAll(dir)
+		return "", err
+	}
+	createdTempDirs = append(createdTempDirs, dir)
+	return dir, nil
+}
+
 func main() {
 	options = ParseOptions()
 	// register owner and ensure cleanup runs once on exit or signal

--- a/cmd/mapcidr/main_test.go
+++ b/cmd/mapcidr/main_test.go
@@ -431,6 +431,10 @@ func TestProcess(t *testing.T) {
 }
 
 func TestProcessRemovesIPRangerTempDir(t *testing.T) {
+	foreign, err := os.MkdirTemp("", "mapcidr-foreign-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(foreign) })
+
 	before := globTempDirs(t)
 
 	options = &Options{FileCidr: []string{"192.0.2.0/30"}, Aggregate: true}
@@ -453,6 +457,8 @@ func TestProcessRemovesIPRangerTempDir(t *testing.T) {
 			t.Fatalf("ipranger temp dir left behind: %s", dir)
 		}
 	}
+	_, err = os.Stat(foreign)
+	require.NoError(t, err, "unrelated mapcidr* temp dir must not be removed")
 }
 
 func TestIPRangerCloseRemovesDiskStore(t *testing.T) {

--- a/cmd/mapcidr/main_test.go
+++ b/cmd/mapcidr/main_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/projectdiscovery/ipranger"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -428,36 +430,56 @@ func TestProcess(t *testing.T) {
 	}
 }
 
-// Test that cleanupTempDirs only removes directories owned by this process.
-func TestCleanupTempDirsOnlyRemovesOwned(t *testing.T) {
-	// ensure owner is set
-	registerTempOwner()
-	// create owned temp dir
-	owned, err := CreateOwnedTempDir("")
-	if err != nil {
-		t.Fatalf("failed to create owned temp dir: %v", err)
-	}
-	// create an unowned temp dir
-	unowned, err := os.MkdirTemp("", "mapcidr-unowned-")
-	if err != nil {
-		t.Fatalf("failed to create unowned temp dir: %v", err)
-	}
-	// ensure unowned does NOT have owner file
-	_ = os.Remove(filepath.Join(unowned, ".mapcidr-owner"))
+func TestProcessRemovesIPRangerTempDir(t *testing.T) {
+	before := globTempDirs(t)
 
-	// run cleanup
-	cleanupTempDirs()
+	options = &Options{FileCidr: []string{"192.0.2.0/30"}, Aggregate: true}
+	chancidr := make(chan string)
+	outputchan := make(chan string)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go process(&wg, chancidr, outputchan)
+	go func() {
+		for range outputchan {
+		}
+	}()
+	chancidr <- "192.0.2.0/30"
+	close(chancidr)
+	wg.Wait()
 
-	// owned should be removed
-	if _, err := os.Stat(owned); !os.IsNotExist(err) {
-		t.Fatalf("owned temp dir was not removed")
-	}
-	// unowned should still exist
-	if _, err := os.Stat(unowned); err != nil {
-		if os.IsNotExist(err) {
-			t.Fatalf("unowned temp dir was removed")
+	after := globTempDirs(t)
+	for dir := range after {
+		if _, ok := before[dir]; !ok {
+			t.Fatalf("ipranger temp dir left behind: %s", dir)
 		}
 	}
-	// cleanup unowned
-	_ = os.RemoveAll(unowned)
+}
+
+func TestIPRangerCloseRemovesDiskStore(t *testing.T) {
+	before := globTempDirs(t)
+	ranger, err := ipranger.New()
+	require.NoError(t, err)
+	created := map[string]struct{}{}
+	for dir := range globTempDirs(t) {
+		if _, ok := before[dir]; !ok {
+			created[dir] = struct{}{}
+		}
+	}
+	require.NotEmpty(t, created, "ipranger.New should create a temp disk store")
+	require.NoError(t, ranger.Close())
+	for dir := range created {
+		_, err := os.Stat(dir)
+		require.True(t, os.IsNotExist(err), "closed ranger must remove %s", dir)
+	}
+}
+
+func globTempDirs(t *testing.T) map[string]struct{} {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(os.TempDir(), "mapcidr*"))
+	require.NoError(t, err)
+	out := make(map[string]struct{}, len(matches))
+	for _, m := range matches {
+		out[m] = struct{}{}
+	}
+	return out
 }

--- a/cmd/mapcidr/main_test.go
+++ b/cmd/mapcidr/main_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -425,4 +426,38 @@ func TestProcess(t *testing.T) {
 		})
 
 	}
+}
+
+// Test that cleanupTempDirs only removes directories owned by this process.
+func TestCleanupTempDirsOnlyRemovesOwned(t *testing.T) {
+	// ensure owner is set
+	registerTempOwner()
+	// create owned temp dir
+	owned, err := CreateOwnedTempDir("")
+	if err != nil {
+		t.Fatalf("failed to create owned temp dir: %v", err)
+	}
+	// create an unowned temp dir
+	unowned, err := os.MkdirTemp("", "mapcidr-unowned-")
+	if err != nil {
+		t.Fatalf("failed to create unowned temp dir: %v", err)
+	}
+	// ensure unowned does NOT have owner file
+	_ = os.Remove(filepath.Join(unowned, ".mapcidr-owner"))
+
+	// run cleanup
+	cleanupTempDirs()
+
+	// owned should be removed
+	if _, err := os.Stat(owned); !os.IsNotExist(err) {
+		t.Fatalf("owned temp dir was not removed")
+	}
+	// unowned should still exist
+	if _, err := os.Stat(unowned); err != nil {
+		if os.IsNotExist(err) {
+			t.Fatalf("unowned temp dir was removed")
+		}
+	}
+	// cleanup unowned
+	_ = os.RemoveAll(unowned)
 }

--- a/cmd/mapcidr/main_test.go
+++ b/cmd/mapcidr/main_test.go
@@ -462,6 +462,10 @@ func TestProcessRemovesIPRangerTempDir(t *testing.T) {
 }
 
 func TestIPRangerCloseRemovesDiskStore(t *testing.T) {
+	foreign, err := os.MkdirTemp("", "mapcidr-foreign-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(foreign) })
+
 	before := globTempDirs(t)
 	ranger, err := ipranger.New()
 	require.NoError(t, err)
@@ -477,6 +481,8 @@ func TestIPRangerCloseRemovesDiskStore(t *testing.T) {
 		_, err := os.Stat(dir)
 		require.True(t, os.IsNotExist(err), "closed ranger must remove %s", dir)
 	}
+	_, err = os.Stat(foreign)
+	require.NoError(t, err, "unrelated mapcidr* temp dir must not be removed")
 }
 
 func globTempDirs(t *testing.T) map[string]struct{} {


### PR DESCRIPTION
Fixes removal of temporary directories: only removes /tmp/mapcidr* directories created by this process. Added CreateOwnedTempDir() which writes a .mapcidr-owner marker (PID), registerTempOwner(), and guarded cleanup that only removes dirs with matching marker and under os.TempDir(). Added unit test TestCleanupTempDirsOnlyRemovesOwned. Closes #827.

(Updated branch: fix-temp-files-827)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary storage created during CIDR processing is now properly closed and removed after processing completes.
  * Fatal errors during IP range processing now clean up temporary storage before the application exits.
  * Failures when initializing IP range processing are now handled instead of continuing with an invalid setup.
  * Cleanup is tied to processing completion rather than broader exit- or interruption-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->